### PR TITLE
Refactor logging, plugin management and job state

### DIFF
--- a/src/MediaBedrock.Cli.Application/Jobs/Handlers/ProcessJobStep.cs
+++ b/src/MediaBedrock.Cli.Application/Jobs/Handlers/ProcessJobStep.cs
@@ -6,6 +6,7 @@ using MediaBedrock.Cli.Domain.Jobs.Assets;
 using MediaBedrock.Cli.Domain.Jobs.Steps;
 using MediaBedrock.Sdk.Processors;
 using Microsoft.Extensions.Logging;
+using Serilog.Context;
 
 namespace MediaBedrock.Cli.Application.Jobs.Handlers;
 
@@ -24,6 +25,15 @@ public sealed class ProcessJobStepHandler(
 {
     public async Task HandleAsync(JobMessageContext<ProcessJobStep> context, CancellationToken ct = default)
     {
+        const string jobIdPropertyName = "JobId";
+        const string jobStepNamePropertyName = "JobStepName";
+        const string jobActivityIdPropertyName = "JobActivityId";
+        const string processorNamePropertyName = "ProcessorName";
+
+        logger.LogInformation("Processing job step {StepName} for job {JobId}",
+            context.JobMessage.StepName,
+            context.JobMessage.JobId);
+
         var jobActivity = context.JobStateMachine.JobActivities
             .SingleOrDefault(ja => ja.Step.Name.Equals(context.JobMessage.StepName));
 
@@ -32,17 +42,6 @@ public sealed class ProcessJobStepHandler(
             logger.LogError("Job step {StepName} not found in job {JobId}",
                 context.JobMessage.StepName,
                 context.JobMessage.JobId);
-            return;
-        }
-
-        var createContext = processorContextFactory.Create(
-            jobId: context.JobMessage.JobId,
-            step: jobActivity.Step,
-            assetsPool: context.JobStateMachine.AssetsPool);
-
-        if (createContext.IsFailure)
-        {
-            logger.LogError("Failed to create job {JobId}", createContext.Error.Message);
             return;
         }
 
@@ -55,28 +54,46 @@ public sealed class ProcessJobStepHandler(
             return;
         }
 
+        var createContext = processorContextFactory.Create(
+            processorType: resolveProcessor.Value.GetType(),
+            jobId: context.JobMessage.JobId,
+            step: jobActivity.Step,
+            assetsPool: context.JobStateMachine.AssetsPool);
+
+        if (createContext.IsFailure)
+        {
+            logger.LogError("Failed to create job {JobId}", createContext.Error.Message);
+            return;
+        }
+
         jobActivity.UpdateStatus(JobActivityStatus.Running);
 
-        try
+        using (LogContext.PushProperty(jobIdPropertyName, context.JobStateMachine.JobId))
+        using (LogContext.PushProperty(jobStepNamePropertyName, context.JobMessage.StepName))
+        using (LogContext.PushProperty(jobActivityIdPropertyName, jobActivity.Id))
+        using (LogContext.PushProperty(processorNamePropertyName, jobActivity.Step.ProcessorName))
         {
-            var processResult = await resolveProcessor.Value.ProcessAsync(createContext.Value, ct);
-            if (!processResult.IsSuccess)
+            try
+            {
+                var processResult = await resolveProcessor.Value.ProcessAsync(createContext.Value, ct);
+                if (!processResult.IsSuccess)
+                {
+                    jobActivity.UpdateStatus(JobActivityStatus.Failed);
+                    logger.LogError("Failed to process job step {StepName} for job {JobId}: {ErrorMessage}",
+                        context.JobMessage.StepName,
+                        context.JobMessage.JobId,
+                        processResult.Message);
+                    return;
+                }
+            }
+            catch (Exception e)
             {
                 jobActivity.UpdateStatus(JobActivityStatus.Failed);
-                logger.LogError("Failed to process job step {StepName} for job {JobId}: {ErrorMessage}",
+                logger.LogError(e, "Failed to process job step {StepName} for job {JobId}",
                     context.JobMessage.StepName,
-                    context.JobMessage.JobId,
-                    processResult.Message);
+                    context.JobMessage.JobId);
                 return;
             }
-        }
-        catch (Exception e)
-        {
-            jobActivity.UpdateStatus(JobActivityStatus.Failed);
-            logger.LogError(e, "Failed to process job step {StepName} for job {JobId}",
-                context.JobMessage.StepName,
-                context.JobMessage.JobId);
-            return;
         }
 
         var updateAssetPool = await UpdateAssetPoolAsync(context.JobStateMachine, createContext.Value);

--- a/src/MediaBedrock.Cli.Application/Jobs/Interfaces/IProcessorContextFactory.cs
+++ b/src/MediaBedrock.Cli.Application/Jobs/Interfaces/IProcessorContextFactory.cs
@@ -8,5 +8,5 @@ namespace MediaBedrock.Cli.Application.Jobs.Interfaces;
 
 public interface IProcessorContextFactory
 {
-    Result<ProcessorContext> Create(JobId jobId, JobStep step, JobAssetsPool assetsPool);
+    Result<ProcessorContext> Create(Type processorType, JobId jobId, JobStep step, JobAssetsPool assetsPool);
 }

--- a/src/MediaBedrock.Cli.Application/Jobs/ProcessorContextFactory.cs
+++ b/src/MediaBedrock.Cli.Application/Jobs/ProcessorContextFactory.cs
@@ -4,12 +4,15 @@ using MediaBedrock.Cli.Domain.Jobs;
 using MediaBedrock.Cli.Domain.Jobs.Assets;
 using MediaBedrock.Cli.Domain.Jobs.Steps;
 using MediaBedrock.Sdk.Processors;
+using Microsoft.Extensions.Logging;
 
 namespace MediaBedrock.Cli.Application.Jobs;
 
-public sealed class ProcessorContextFactory(IProcessorProvider processorProvider) : IProcessorContextFactory
+public sealed class ProcessorContextFactory(
+    IProcessorProvider processorProvider,
+    ILoggerFactory loggerFactory) : IProcessorContextFactory
 {
-    public Result<ProcessorContext> Create(JobId jobId, JobStep step, JobAssetsPool assetsPool)
+    public Result<ProcessorContext> Create(Type processorType, JobId jobId, JobStep step, JobAssetsPool assetsPool)
     {
         var properties = step.Properties.Select(p => new ProcessorProperty(p.Name, p.Value)).ToList();
 
@@ -67,7 +70,11 @@ public sealed class ProcessorContextFactory(IProcessorProvider processorProvider
             processorOutputs.Add(processorOutput);
         }
 
-        var context = ProcessorContext.Create(processorInputs, processorOutputs, properties);
+        var context = ProcessorContext.Create(
+            logger: loggerFactory.CreateLogger(processorType),
+            inputs: processorInputs,
+            outputs: processorOutputs,
+            properties: properties);
         return Result.Created(context);
     }
 }

--- a/src/MediaBedrock.Cli.Application/MediaBedrock.Cli.Application.csproj
+++ b/src/MediaBedrock.Cli.Application/MediaBedrock.Cli.Application.csproj
@@ -11,8 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4"/>
+        <PackageReference Include="Serilog" Version="4.2.0"/>
     </ItemGroup>
 
 </Project>

--- a/src/MediaBedrock.Cli.Domain/Jobs/JobStateMachine.cs
+++ b/src/MediaBedrock.Cli.Domain/Jobs/JobStateMachine.cs
@@ -25,6 +25,7 @@ public sealed class JobActivity
     {
     }
 
+    public required Guid Id { get; init; }
     public required JobStep Step { get; init; }
     public JobActivityStatus Status { get; private set; }
 
@@ -32,6 +33,7 @@ public sealed class JobActivity
     {
         return new JobActivity
         {
+            Id = Guid.CreateVersion7(),
             Step = step,
             Status = JobActivityStatus.Pending
         };

--- a/src/MediaBedrock.Cli.Infrastructure/MediaBedrock.Cli.Infrastructure.csproj
+++ b/src/MediaBedrock.Cli.Infrastructure/MediaBedrock.Cli.Infrastructure.csproj
@@ -13,11 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4"/>
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1"/>
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0"/>
     </ItemGroup>

--- a/src/MediaBedrock.Cli.Infrastructure/Plugins/PluginsManager.cs
+++ b/src/MediaBedrock.Cli.Infrastructure/Plugins/PluginsManager.cs
@@ -1,16 +1,12 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Autofac;
-using Autofac.Extensions.DependencyInjection;
 using Coderynx.Functional.Results;
 using MediaBedrock.Cli.Domain.Jobs.Processors;
 using MediaBedrock.Cli.Infrastructure.Plugins.Interfaces;
 using MediaBedrock.Sdk.Processors;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Serilog;
 
 namespace MediaBedrock.Cli.Infrastructure.Plugins;
 
@@ -21,7 +17,7 @@ public sealed record PluginConfiguration
 
 internal sealed record PluginEntry(Assembly Assembly, PluginConfiguration Configuration);
 
-public sealed class PluginsManager(ILogger<PluginsManager> logger, IConfiguration configuration) : IPluginsManager
+public sealed class PluginsManager(ILogger<PluginsManager> logger) : IPluginsManager
 {
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -31,14 +27,11 @@ public sealed class PluginsManager(ILogger<PluginsManager> logger, IConfiguratio
         }
     };
 
-    private IContainer? _container;
+    private IServiceProvider? _serviceProvider;
 
     public void Initialize()
     {
-        var builder = new ContainerBuilder();
-
-        var coreServices = AddCoreServices();
-        builder.Populate(coreServices);
+        var serviceCollection = new ServiceCollection();
 
         var plugins = LoadPlugins();
 
@@ -52,41 +45,52 @@ public sealed class PluginsManager(ILogger<PluginsManager> logger, IConfiguratio
                 var processorInfo = GetProcessorInfo(type);
                 var fullName = $"{processorInfo.Namespace}/{processorInfo.Name}";
 
-                builder.RegisterType(type).Named<IProcessor>(fullName);
+                serviceCollection.AddKeyedTransient(fullName, (sp, _) =>
+                    (IProcessor)ActivatorUtilities.CreateInstance(sp, type));
+
                 logger.LogInformation("Registered processor {ProcessorFullName}", fullName);
             }
 
             foreach (var processorConfiguration in plugin.Configuration.Processors)
             {
-                builder.RegisterInstance(processorConfiguration)
-                    .Named<ProcessorConfiguration>(processorConfiguration.Name);
+                serviceCollection.AddKeyedSingleton(processorConfiguration.Name, processorConfiguration);
                 logger.LogInformation("Registered processor configuration {ProcessorConfigurationName}",
                     processorConfiguration.Name);
             }
         }
 
-        _container = builder.Build();
+        _serviceProvider = serviceCollection.BuildServiceProvider();
 
         logger.LogInformation("Plugins loaded");
     }
 
     public Result<TComponent> ResolveComponent<TComponent>(string name) where TComponent : class
     {
-        if (_container is null)
+        if (_serviceProvider is null)
         {
             return PluginErrors.ContainerNotInitialized;
         }
 
-        return _container.TryResolveNamed<TComponent>(name, out var adapter)
-            ? Result.Found(adapter)
-            : ProcessorErrors.NotFound(name);
+        var service = _serviceProvider.GetKeyedService<TComponent>(name);
+
+        return service is null
+            ? ProcessorErrors.NotFound(name)
+            : Result.Found(service);
     }
 
     public async ValueTask DisposeAsync()
     {
-        if (_container is not null)
+        if (_serviceProvider is not null)
         {
-            await _container.DisposeAsync();
+            switch (_serviceProvider)
+            {
+                case IAsyncDisposable asyncDisposable:
+                    await asyncDisposable.DisposeAsync();
+                    break;
+                case IDisposable disposable:
+                    disposable.Dispose();
+                    break;
+            }
         }
     }
 
@@ -100,22 +104,6 @@ public sealed class PluginsManager(ILogger<PluginsManager> logger, IConfiguratio
         }
 
         return (attribute.Namespace, attribute.Name);
-    }
-
-    private ServiceCollection AddCoreServices()
-    {
-        var collection = new ServiceCollection();
-
-        collection.AddLogging(loggingBuilder =>
-        {
-            var serilog = new LoggerConfiguration()
-                .ReadFrom.Configuration(configuration)
-                .CreateLogger();
-
-            loggingBuilder.AddSerilog(serilog);
-        });
-
-        return collection;
     }
 
     private List<PluginEntry> LoadPlugins()

--- a/src/MediaBedrock.Cli.Presentation/MediaBedrock.Cli.Presentation.csproj
+++ b/src/MediaBedrock.Cli.Presentation/MediaBedrock.Cli.Presentation.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="Cocona.Core" Version="2.2.0"/>
-        <PackageReference Include="Spectre.Console" Version="0.50.0" />
-        <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
+        <PackageReference Include="Spectre.Console" Version="0.50.0"/>
+        <PackageReference Include="Spectre.Console.Json" Version="0.50.0"/>
     </ItemGroup>
 
 </Project>

--- a/src/MediaBedrock.Cli/MediaBedrock.Cli.csproj
+++ b/src/MediaBedrock.Cli/MediaBedrock.Cli.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="Cocona" Version="2.2.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.4"/>
         <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
-        <PackageReference Include="Spectre.Console" Version="0.50.0" />
-        <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
+        <PackageReference Include="Spectre.Console" Version="0.50.0"/>
+        <PackageReference Include="Spectre.Console.Json" Version="0.50.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MediaBedrock.Dolby.Example/MediaBedrock.Dolby.Example.csproj
+++ b/src/MediaBedrock.Dolby.Example/MediaBedrock.Dolby.Example.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Spectre.Console" Version="0.50.0" />
+        <PackageReference Include="Spectre.Console" Version="0.50.0"/>
     </ItemGroup>
 
 </Project>

--- a/src/MediaBedrock.Dolby.Extensions.DependencyInjection/MediaBedrock.Dolby.Extensions.DependencyInjection.csproj
+++ b/src/MediaBedrock.Dolby.Extensions.DependencyInjection/MediaBedrock.Dolby.Extensions.DependencyInjection.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MediaBedrock.Dolby/EncodingEngine/DolbyEncodingEngine.cs
+++ b/src/MediaBedrock.Dolby/EncodingEngine/DolbyEncodingEngine.cs
@@ -16,7 +16,7 @@ public sealed partial class DolbyEncodingEngine : IDolbyEncodingEngine
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    private readonly ILogger<DolbyEncodingEngine>? _logger;
+    private readonly ILogger? _logger;
 
     public DolbyEncodingEngine(string path, bool useWine = false)
     {
@@ -29,6 +29,11 @@ public sealed partial class DolbyEncodingEngine : IDolbyEncodingEngine
     public DolbyEncodingEngine(string path, bool useWine, ILoggerFactory loggerFactory) : this(path, useWine)
     {
         _logger = loggerFactory.CreateLogger<DolbyEncodingEngine>();
+    }
+
+    public DolbyEncodingEngine(string path, bool useWine, ILogger logger) : this(path, useWine)
+    {
+        _logger = logger;
     }
 
     private bool IsInitialized => !string.IsNullOrEmpty(Version);

--- a/src/MediaBedrock.Dolby/MediaBedrock.Dolby.csproj
+++ b/src/MediaBedrock.Dolby/MediaBedrock.Dolby.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4"/>
     </ItemGroup>
 
 </Project>

--- a/src/MediaBedrock.Plugins.Core/MediaBedrock.Plugins.Core.csproj
+++ b/src/MediaBedrock.Plugins.Core/MediaBedrock.Plugins.Core.csproj
@@ -11,7 +11,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
         <PackageReference Include="z440.atl.core" Version="6.20.0"/>
     </ItemGroup>
 

--- a/src/MediaBedrock.Plugins.Core/MetadataWriter.cs
+++ b/src/MediaBedrock.Plugins.Core/MetadataWriter.cs
@@ -5,21 +5,21 @@ using Microsoft.Extensions.Logging;
 namespace MediaBedrock.Plugins.Core;
 
 [Processor("core", "metadata-writer")]
-public sealed class MetadataWriter(ILogger<MetadataWriter> logger) : IProcessor
+public sealed class MetadataWriter : IProcessor
 {
     public async Task<ProcessorResult> ProcessAsync(ProcessorContext context, CancellationToken ct = default)
     {
         var inputTrack = context.GetInput("input");
         if (inputTrack is null)
         {
-            logger.LogError("Input track not found");
+            context.Logger.LogError("Input track not found");
             return ProcessorResult.Failure("Input track not found");
         }
 
         var outputTrack = context.GetOutput("output");
         if (outputTrack is null)
         {
-            logger.LogError("Output track not found");
+            context.Logger.LogError("Output track not found");
             return ProcessorResult.Failure("Output track not found");
         }
 
@@ -44,7 +44,7 @@ public sealed class MetadataWriter(ILogger<MetadataWriter> logger) : IProcessor
 
         await track.SaveToAsync(outputStream);
 
-        logger.LogInformation("Metadata written to {Input}", inputTrack);
+        context.Logger.LogInformation("Metadata written to {Input}", inputTrack);
         return ProcessorResult.Success();
     }
 }

--- a/src/MediaBedrock.Plugins.Core/Probe.cs
+++ b/src/MediaBedrock.Plugins.Core/Probe.cs
@@ -4,11 +4,11 @@ using Microsoft.Extensions.Logging;
 namespace MediaBedrock.Plugins.Core;
 
 [Processor("core", "probe")]
-public sealed class Probe(ILogger<Probe> logger) : IProcessor
+public sealed class Probe : IProcessor
 {
     public Task<ProcessorResult> ProcessAsync(ProcessorContext context, CancellationToken ct = default)
     {
-        logger.LogInformation("Received ProcessorContext: {@Context}", context);
+        context.Logger.LogInformation("Received ProcessorContext: {@Context}", context);
 
         return Task.FromResult(ProcessorResult.Success());
     }

--- a/src/MediaBedrock.Plugins.Dolby/DolbyDigitalPlusEncoder.cs
+++ b/src/MediaBedrock.Plugins.Dolby/DolbyDigitalPlusEncoder.cs
@@ -9,31 +9,31 @@ using Microsoft.Extensions.Logging;
 namespace MediaBedrock.Plugins.Dolby;
 
 [Processor("dolby", "ddp-encoder")]
-public sealed class DolbyDigitalPlusEncoder(
-    ILogger<DolbyDigitalPlusEncoder> logger,
-    ILoggerFactory loggerFactory)
+public sealed class DolbyDigitalPlusEncoder
     : IProcessor
 {
     public async Task<ProcessorResult> ProcessAsync(ProcessorContext context, CancellationToken ct = default)
     {
+        context.Logger.LogDebug("Processing Dolby Digital Plus encoder {JobId}", "11");
+
         var inputTrack = context.GetInput("input");
         if (inputTrack is null)
         {
-            logger.LogError("Input track not found");
+            context.Logger.LogError("Input track not found");
             return ProcessorResult.Failure("Input track not found");
         }
 
         var outputTrack = context.GetOutput("output");
         if (outputTrack is null)
         {
-            logger.LogError("Output track not found");
+            context.Logger.LogError("Output track not found");
             return ProcessorResult.Failure("Output track not found");
         }
 
         var inputUri = inputTrack.GetAsFilePath();
         var outputUri = outputTrack.GetAsFilePath();
 
-        logger.LogInformation("Encoding {Input} to {Output}", inputUri, outputUri);
+        context.Logger.LogInformation("Encoding {Input} to {Output}", inputUri, outputUri);
 
         var job = JobDefinition.CreateBuilder();
 
@@ -81,11 +81,11 @@ public sealed class DolbyDigitalPlusEncoder(
         var engine = new DolbyEncodingEngine(
             path: enginePath,
             useWine: useWine,
-            loggerFactory: loggerFactory);
+            logger: context.Logger);
 
         await engine.ProcessJobAsync(jobDefinition);
 
-        logger.LogInformation("Successfully encoded {Input} to {Output}", inputUri, outputUri);
+        context.Logger.LogInformation("Successfully encoded {Input} to {Output}", inputUri, outputUri);
 
         return ProcessorResult.Success();
     }

--- a/src/MediaBedrock.Plugins.Dolby/DolbyDigitalPlusEncoder.cs
+++ b/src/MediaBedrock.Plugins.Dolby/DolbyDigitalPlusEncoder.cs
@@ -14,8 +14,6 @@ public sealed class DolbyDigitalPlusEncoder
 {
     public async Task<ProcessorResult> ProcessAsync(ProcessorContext context, CancellationToken ct = default)
     {
-        context.Logger.LogDebug("Processing Dolby Digital Plus encoder {JobId}", "11");
-
         var inputTrack = context.GetInput("input");
         if (inputTrack is null)
         {

--- a/src/MediaBedrock.Sdk/MediaBedrock.Sdk.csproj
+++ b/src/MediaBedrock.Sdk/MediaBedrock.Sdk.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4"/>
+    </ItemGroup>
+
 </Project>

--- a/src/MediaBedrock.Sdk/Processors/ProcessorContext.cs
+++ b/src/MediaBedrock.Sdk/Processors/ProcessorContext.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace MediaBedrock.Sdk.Processors;
 
 public sealed record ProcessorContext
@@ -7,6 +9,8 @@ public sealed record ProcessorContext
     private IEnumerable<ProcessorProperty> _properties = [];
 
     public IReadOnlyCollection<ProcessorOutput> Outputs => _outputs.ToArray();
+
+    public required ILogger Logger { get; init; }
 
     public ProcessorInput GetInputRequired(string name)
     {
@@ -42,12 +46,14 @@ public sealed record ProcessorContext
     }
 
     public static ProcessorContext Create(
+        ILogger logger,
         IEnumerable<ProcessorInput> inputs,
         IEnumerable<ProcessorOutput> outputs,
         IEnumerable<ProcessorProperty> properties)
     {
         return new ProcessorContext
         {
+            Logger = logger,
             _inputs = inputs,
             _outputs = outputs,
             _properties = properties

--- a/tests/MediaBedrock.UnitTests/MediaBedrock.UnitTests.csproj
+++ b/tests/MediaBedrock.UnitTests/MediaBedrock.UnitTests.csproj
@@ -10,16 +10,16 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
         <PackageReference Include="coverlet.collector" Version="6.0.4">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
         <PackageReference Include="Shouldly" Version="4.3.0"/>
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
This pull request includes significant changes to the logging system, dependency injection, and processor context handling within the MediaBedrock project. The most important changes include the introduction of Serilog for structured logging, the removal of Autofac in favor of Microsoft.Extensions.DependencyInjection, and updates to the processor context to include logger instances.

### Logging System Enhancements:
* Added Serilog for structured logging and updated the `ProcessJobStepHandler` to use `LogContext` for contextual logging. (`src/MediaBedrock.Cli.Application/Jobs/Handlers/ProcessJobStep.cs`) [[1]](diffhunk://#diff-c5da242efc829f80c78e29ca4d22760b9559d7992b73c3ff84e20da93df4418aR9) [[2]](diffhunk://#diff-c5da242efc829f80c78e29ca4d22760b9559d7992b73c3ff84e20da93df4418aR28-R36) [[3]](diffhunk://#diff-c5da242efc829f80c78e29ca4d22760b9559d7992b73c3ff84e20da93df4418aR48-R58) [[4]](diffhunk://#diff-c5da242efc829f80c78e29ca4d22760b9559d7992b73c3ff84e20da93df4418aL49-R75) [[5]](diffhunk://#diff-c5da242efc829f80c78e29ca4d22760b9559d7992b73c3ff84e20da93df4418aR97)
* Updated `ProcessorContextFactory` to create logger instances for processors. (`src/MediaBedrock.Cli.Application/Jobs/ProcessorContextFactory.cs`) [[1]](diffhunk://#diff-65e39d851721720f9c1df1dae1e1475059cda12fcc3aaff364dfa653a4c41b44R7-R15) [[2]](diffhunk://#diff-65e39d851721720f9c1df1dae1e1475059cda12fcc3aaff364dfa653a4c41b44L70-R77)

### Dependency Injection Changes:
* Removed Autofac and replaced it with Microsoft.Extensions.DependencyInjection for dependency injection. (`src/MediaBedrock.Cli.Infrastructure/Plugins/PluginsManager.cs`) [[1]](diffhunk://#diff-d6f2bd92fb11c2a5be1a48a62fedebc89f5cbb9d3733ec6a1044bbbe74deb48aL4-L13) [[2]](diffhunk://#diff-d6f2bd92fb11c2a5be1a48a62fedebc89f5cbb9d3733ec6a1044bbbe74deb48aL24-R20) [[3]](diffhunk://#diff-d6f2bd92fb11c2a5be1a48a62fedebc89f5cbb9d3733ec6a1044bbbe74deb48aL34-R34) [[4]](diffhunk://#diff-d6f2bd92fb11c2a5be1a48a62fedebc89f5cbb9d3733ec6a1044bbbe74deb48aL55-R93) [[5]](diffhunk://#diff-d6f2bd92fb11c2a5be1a48a62fedebc89f5cbb9d3733ec6a1044bbbe74deb48aL105-L120)
* Updated project files to reflect the removal of Autofac and addition of Serilog and Microsoft.Extensions.Logging packages. (`src/MediaBedrock.Cli.Infrastructure/MediaBedrock.Cli.Infrastructure.csproj`, `src/MediaBedrock.Cli.Application/MediaBedrock.Cli.Application.csproj`, `src/MediaBedrock.Sdk/MediaBedrock.Sdk.csproj`) [[1]](diffhunk://#diff-bf67cf01c412b0c7c0f8006755622198f44efe3871d1f0448b7ad581c27007f3L16) [[2]](diffhunk://#diff-63ad488ab5a706f50faa9fade7828114a81271a5bd499adcfac3534d36574975R16) [[3]](diffhunk://#diff-5e00183086d3872993f6ca52a0d709cabef319abaff065bd41ff7aa5d063cdbdR9-R12)

### Processor Context Updates:
* Modified `ProcessorContext` to include a logger instance and updated processors to use this logger for logging. (`src/MediaBedrock.Sdk/Processors/ProcessorContext.cs`, `src/MediaBedrock.Plugins.Core/MetadataWriter.cs`, `src/MediaBedrock.Plugins.Core/Probe.cs`, `src/MediaBedrock.Plugins.Dolby/DolbyDigitalPlusEncoder.cs`) [[1]](diffhunk://#diff-7cf01a8fa081ff22f6aa6489ffae7666b2f4f7fe0962d9b69a3d5cfd024d6f3fR1-R2) [[2]](diffhunk://#diff-3b42394f04da9432c67a31f8550b015fba8b726ef77678b5e1fe7ed1fde7a768L8-R22) [[3]](diffhunk://#diff-3b42394f04da9432c67a31f8550b015fba8b726ef77678b5e1fe7ed1fde7a768L47-R47) [[4]](diffhunk://#diff-54c9e83ddf9a2212f982f35780c32959c1acf0511ba7c434e9d5f1bde4b23645L7-R11) [[5]](diffhunk://#diff-30baa7542125c8e6ced111890c39be2c04555b820ed41f520c2c62740c12921bL12-R36) [[6]](diffhunk://#diff-30baa7542125c8e6ced111890c39be2c04555b820ed41f520c2c62740c12921bL84-R88)

### Additional Changes:
* Added a required `Id` property to `JobActivity` to uniquely identify each job activity. (`src/MediaBedrock.Cli.Domain/Jobs/JobStateMachine.cs`)
* Introduced a new constructor in `DolbyEncodingEngine` to accept a logger instance directly. (`src/MediaBedrock.Dolby/EncodingEngine/DolbyEncodingEngine.cs`) [[1]](diffhunk://#diff-b5aa67f4ee26dba6d820cda1b7f07535beceead1c2ecaa618f3752b215f9ed22L19-R19) [[2]](diffhunk://#diff-b5aa67f4ee26dba6d820cda1b7f07535beceead1c2ecaa618f3752b215f9ed22R34-R38)